### PR TITLE
Fix some shard conversions per new naming

### DIFF
--- a/conversionupdating/bazaar-conversions.json
+++ b/conversionupdating/bazaar-conversions.json
@@ -1646,7 +1646,7 @@
   "SHARD_STALAGMIGHT": "Stalagmight Shard",
   "SHARD_STAR_SENTRY": "Star Sentry Shard",
   "SHARD_STARBORN": "Starborn Shard",
-  "SHARD_STRIDER_SURFER": "Strider Surfer Shard",
+  "SHARD_STRIDER_SURFER": "Stridersurfer Shard",
   "SHARD_SUN_FISH": "Sun Fish Shard",
   "SHARD_SYCOPHANT": "Sycophant Shard",
   "SHARD_SYLVAN": "Sylvan Shard",

--- a/conversionupdating/bazaar-conversions.json
+++ b/conversionupdating/bazaar-conversions.json
@@ -1526,7 +1526,7 @@
   "SHARD_CAVERNSHADE": "Cavernshade Shard",
   "SHARD_CHAMELEON": "Chameleon Shard",
   "SHARD_CHILL": "Chill Shard",
-  "SHARD_CINDER_BAT": "Cinder Bat Shard",
+  "SHARD_CINDER_BAT": "Cinderbat Shard",
   "SHARD_COD": "Cod Shard",
   "SHARD_CONDOR": "Condor Shard",
   "SHARD_CORALOT": "Coralot Shard",

--- a/conversionupdating/scripts/generate-bazaar-conversions.ts
+++ b/conversionupdating/scripts/generate-bazaar-conversions.ts
@@ -35,10 +35,13 @@ const PLACEHOLDER_PATTERN = /%%\w+%%/g;
 
 // Manual overrides for awkward IDs whose official item name might be null or undesirable
 const NAME_OVERRIDES: Record<string, string> = {
-    // Bogged Shard
+    // Shards
     SHARD_SEA_ARCHER: "Bogged Shard",
 
     SHARD_ENDSTONE_PROTECTOR: "End Stone Protector Shard",
+
+    SHARD_CINDER_BAT: "Cinderbat Shard",
+    SHARD_STRIDER_SURFER: "Stridersurfer Shard",
 
     // Prismatic
     ENCHANTMENT_PRISTINE_1: "Prismatic I",


### PR DESCRIPTION
new names

- Cinder Bat Shard -> Cinderbat Shard
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f2489339-87c5-4f42-b8a7-6989058e7713" />

- Strider Surfer Shard -> Stridersurfer Shard
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a5a97399-6374-490b-959c-24b98615bd92" />

